### PR TITLE
Add ridge regression and lambda tuning to the How-to tutorial

### DIFF
--- a/docs/literate/HowTo/overlapcorrectedLDA_options.jl
+++ b/docs/literate/HowTo/overlapcorrectedLDA_options.jl
@@ -54,3 +54,72 @@ uf_lda = UnfoldDecode.fit(
 plot_erp(coeftable(uf_lda))
 
 # Voila, the model classified the correct period at the correct event
+
+# ## Fitting the Overlap-corrected Ridge Regression model 
+RidgeRegressor = @load RidgeRegressor pkg=MLJLinearModels
+
+# you could use other parameters, check out `?RidgeRegressor`
+ridgeModel = RidgeRegressor(
+    lambda = 1.0, 
+    fit_intercept = true,
+    penalize_intercept = false,
+)
+
+# change the setting in MLJ to allow for continuous predictions
+MLJ.machine(
+    model::RidgeRegressor,
+    X::AbstractMatrix{Float64},
+    y::SubArray{Float64};
+    kwargs...,
+) = MLJ.machine(
+    model,
+    MLJ.table(X),
+    y;
+    kwargs...,
+)
+
+# load the model
+uf_ridge =Unfold.fit(
+    UnfoldDecodingModel,
+    des, 
+    evt, 
+    dat, 
+    ridgeModel, 
+    "eventA" => :continuous; 
+    nfolds = 2, 
+    predict_type=Continuous)
+
+
+ridge_scores = coeftable(uf_ridge,measure=RSquared())
+plot_erp(ridge_scores; mapping = (; color = :estimate))
+
+# Voila again, the model can predict the correct period at the correct event
+
+# ## Grid search for ridge regression lambda parameter
+r = range(
+		ridgeModel,
+		:lambda;
+		lower = 1e-6,
+		upper = 1e2,
+		scale = :log,
+	)
+
+ridgeTunedModel = TunedModel(
+	model=ridgeModel,
+	resampling=CV(nfolds=3),
+	range = r,
+	tuning=Grid(resolution=4), # test 4 λ values on a logarithmic scale
+	measure = RSquared(),
+)
+
+
+# Now we can fit the model with the tuned hyperparameter
+uf_ridge_tuned =Unfold.fit(
+    UnfoldDecodingModel, 
+    des, 
+    evt, 
+    dat, 
+    ridgeTunedModel, 
+    "eventA" => :continuous; 
+    nfolds = 2, 
+    predict_type=Continuous)

--- a/docs/literate/HowTo/overlapcorrectedLDA_options.jl
+++ b/docs/literate/HowTo/overlapcorrectedLDA_options.jl
@@ -66,6 +66,7 @@ ridgeModel = RidgeRegressor(
 )
 
 # change the setting in MLJ to allow for continuous predictions
+
 MLJ.machine(
     model::RidgeRegressor,
     X::AbstractMatrix{Float64},
@@ -79,7 +80,7 @@ MLJ.machine(
 )
 
 # load the model
-uf_ridge =Unfold.fit(
+uf_ridge = Unfold.fit(
     UnfoldDecodingModel,
     des, 
     evt, 
@@ -96,6 +97,8 @@ plot_erp(ridge_scores; mapping = (; color = :estimate))
 # Voila again, the model can predict the correct period at the correct event
 
 # ## Grid search for ridge regression lambda parameter
+
+# We can use MLJ's built-in tuning functionality to perform a grid search over the lambda parameter for ridge regression. 
 r = range(
 		ridgeModel,
 		:lambda;
@@ -114,7 +117,7 @@ ridgeTunedModel = TunedModel(
 
 
 # Now we can fit the model with the tuned hyperparameter
-uf_ridge_tuned =Unfold.fit(
+uf_ridge_tuned = Unfold.fit(
     UnfoldDecodingModel, 
     des, 
     evt, 

--- a/docs/literate/HowTo/overlapcorrectedLDA_options.jl
+++ b/docs/literate/HowTo/overlapcorrectedLDA_options.jl
@@ -55,15 +55,11 @@ plot_erp(coeftable(uf_lda))
 
 # Voila, the model classified the correct period at the correct event
 
-# ## Fitting the Overlap-corrected Ridge Regression model 
+# ## Fitting the Overlap-corrected Ridge Regression model
 RidgeRegressor = @load RidgeRegressor pkg=MLJLinearModels
 
 # you could use other parameters, check out `?RidgeRegressor`
-ridgeModel = RidgeRegressor(
-    lambda = 1.0, 
-    fit_intercept = true,
-    penalize_intercept = false,
-)
+ridgeModel = RidgeRegressor(lambda = 1.0, fit_intercept = true, penalize_intercept = false)
 
 # change the setting in MLJ to allow for continuous predictions
 
@@ -72,57 +68,48 @@ MLJ.machine(
     X::AbstractMatrix{Float64},
     y::SubArray{Float64};
     kwargs...,
-) = MLJ.machine(
-    model,
-    MLJ.table(X),
-    y;
-    kwargs...,
-)
+) = MLJ.machine(model, MLJ.table(X), y; kwargs...)
 
 # load the model
 uf_ridge = Unfold.fit(
     UnfoldDecodingModel,
-    des, 
-    evt, 
-    dat, 
-    ridgeModel, 
-    "eventA" => :continuous; 
-    nfolds = 2, 
-    predict_type=Continuous)
+    des,
+    evt,
+    dat,
+    ridgeModel,
+    "eventA" => :continuous;
+    nfolds = 2,
+    predict_type = Continuous,
+)
 
 
-ridge_scores = coeftable(uf_ridge,measure=RSquared())
+ridge_scores = coeftable(uf_ridge, measure = RSquared())
 plot_erp(ridge_scores; mapping = (; color = :estimate))
 
 # Voila again, the model can predict the correct period at the correct event
 
 # ## Grid search for ridge regression lambda parameter
 
-# We can use MLJ's built-in tuning functionality to perform a grid search over the lambda parameter for ridge regression. 
-r = range(
-		ridgeModel,
-		:lambda;
-		lower = 1e-6,
-		upper = 1e2,
-		scale = :log,
-	)
+# We can use MLJ's built-in tuning functionality to perform a grid search over the lambda parameter for ridge regression.
+r = range(ridgeModel, :lambda; lower = 1e-6, upper = 1e2, scale = :log)
 
 ridgeTunedModel = TunedModel(
-	model=ridgeModel,
-	resampling=CV(nfolds=3),
-	range = r,
-	tuning=Grid(resolution=4), # test 4 λ values on a logarithmic scale
-	measure = RSquared(),
+    model = ridgeModel,
+    resampling = CV(nfolds = 3),
+    range = r,
+    tuning = Grid(resolution = 4), # test 4 λ values on a logarithmic scale
+    measure = RSquared(),
 )
 
 
 # Now we can fit the model with the tuned hyperparameter
 uf_ridge_tuned = Unfold.fit(
-    UnfoldDecodingModel, 
-    des, 
-    evt, 
-    dat, 
-    ridgeTunedModel, 
-    "eventA" => :continuous; 
-    nfolds = 2, 
-    predict_type=Continuous)
+    UnfoldDecodingModel,
+    des,
+    evt,
+    dat,
+    ridgeTunedModel,
+    "eventA" => :continuous;
+    nfolds = 2,
+    predict_type = Continuous,
+)


### PR DESCRIPTION
<!--
Thanks for making a pull request to UnfoldDecode.jl.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide by the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
# Summary 

This PR extends the overlap-corrected decoding How-to tutorial with : 
- continuous decoding using **ridge regression**.
- ridge lambda grid search 


<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x ] I am following the [contributing guidelines](https://github.com/unfoldtoolbox/UnfoldDecode.jl/blob/main/docs/src/90-contributing.md)
- [ x] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
